### PR TITLE
Fix: Update GitHub Actions to current versions (v4)

### DIFF
--- a/.github/workflows/platformio.yml
+++ b/.github/workflows/platformio.yml
@@ -15,18 +15,18 @@ jobs:
         board: [esp32dev]
         
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-          
+
     - name: Cache PlatformIO
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
@@ -57,7 +57,7 @@ jobs:
         pio run -e esp32dev --target size
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: firmware-${{ matrix.board }}
         path: .pio/build/esp32dev/firmware.bin


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing due to using deprecated versions of actions, specifically:
- `actions/upload-artifact@v3` (deprecated April 16, 2024, scheduled for removal November 30, 2024)
- `actions/checkout@v3` and `actions/cache@v3` (also outdated)

The workflow was failing with the error:
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`

## Solution
Updated all GitHub Actions to their current supported versions:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/cache@v3` → `actions/cache@v4`
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`

## Testing
- [x] Workflow syntax validated
- [x] All action versions are current and supported
- [ ] Workflow run verification (will be tested by this PR)

## Breaking Changes
The v4 actions are backward compatible with the current workflow configuration, so no syntax changes were needed beyond version updates.

Fixes the ESP32 development build workflow failures.